### PR TITLE
Ascii graph

### DIFF
--- a/project.sbt
+++ b/project.sbt
@@ -4,7 +4,7 @@ name := "sbt-dependency-graph"
 
 organization := "net.virtual-void"
 
-version := "0.5.2"
+version := "0.5.3-SNAPSHOT"
 
 homepage := Some(url("http://github.com/jrudolph/sbt-dependency-graph"))
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.12.0-Beta2

--- a/src/main/scala/net/virtualvoid/sbt/graph/IvyGraphMLDependencies.scala
+++ b/src/main/scala/net/virtualvoid/sbt/graph/IvyGraphMLDependencies.scala
@@ -18,23 +18,53 @@ package net.virtualvoid.sbt.graph
 
 import xml.parsing.ConstructingParser
 import java.io.File
-import xml.{XML, Node}
+import collection.mutable.HashMap
+import collection.mutable.MultiMap
+import collection.mutable.{Set => MSet}
+import sbt.Graph
+import xml.{Document, XML, Node}
 
 object IvyGraphMLDependencies extends App {
   case class Module(organisation: String, name: String, version: String) {
-    def id: String = organisation+"."+name+"-"+version
+    def id: String = organisation+":"+name+":"+version
   }
-  def transform(ivyReportFile: String, outputFile: String) {
-    val doc = ConstructingParser.fromSource(io.Source.fromFile(ivyReportFile), false).document
 
+  case class ModuleGraph(nodes: Seq[Module], edges: Seq[(Module, Module)])
+
+  def buildGraph(doc: Document): ModuleGraph = {
     val edges = for {
-        mod <- doc \ "dependencies" \ "module"
-        caller <- mod \ "revision" \ "caller"
-        callerModule = nodeFromElement(caller, caller.attribute("callerrev").get.text)
-        depModule = nodeFromElement(mod, caller.attribute("rev").get.text)
-      } yield (callerModule, depModule)
+      mod <- doc \ "dependencies" \ "module"
+      caller <- mod \ "revision" \ "caller"
+      callerModule = nodeFromElement(caller, caller.attribute("callerrev").get.text)
+      depModule = nodeFromElement(mod, caller.attribute("rev").get.text)
+    } yield (callerModule, depModule)
 
     val nodes = edges.flatMap(e => Seq(e._1, e._2)).distinct
+
+    ModuleGraph(nodes, edges)
+  }
+
+
+  def ascii(ivyReportFile: String): String = {
+    val doc = buildDoc(ivyReportFile)
+    val graph = buildGraph(doc)
+    import graph._
+    val deps = {
+      val m = new HashMap[Module, MSet[Module]] with MultiMap[Module, Module]
+      edges.foreach { case (from, to) => m.addBinding(from, to) }
+      m.toMap.mapValues(_.toSeq.sortBy(_.id))
+    }
+    // there should only be one root node (the project itself)
+    val roots = nodes.filter(n => !edges.exists(_._2 == n)).sortBy(_.id)
+    roots.map(root =>
+      Graph.toAscii[Module](root, node => deps.getOrElse(node, Seq.empty[Module]), _.id)
+    ).mkString("\n")
+  }
+
+  def transform(ivyReportFile: String, outputFile: String) {
+    val doc = buildDoc(ivyReportFile)
+    val graph = buildGraph(doc)
+    import graph._
 
     val nodesXml =
       for (n <- nodes)
@@ -63,8 +93,10 @@ object IvyGraphMLDependencies extends App {
 
     XML.save(outputFile, xml)
   }
-  def nodeFromElement(element: Node, version: String): Module =
+  private def nodeFromElement(element: Node, version: String): Module =
     Module(element.attribute("organisation").get.text, element.attribute("name").get.text, version)
+
+  private def buildDoc(ivyReportFile: String) = ConstructingParser.fromSource(io.Source.fromFile(ivyReportFile), false).document
 
   def die(msg: String): Nothing = {
     println(msg)


### PR DESCRIPTION
Hi,
This pull request incorporates pull request #4.
- Nodes are now displayed as `groupId:artifact:version`
- Added 2 new tasks to print the ascii representation of the dependency tree/graph to the console
  - `ascii-graph` returns just the `String` representation
  - `print-ascii-graph` logs the ascii tree to the console on `INFO` level (basically `show ascii-graph`)

You can take a look at a sample output in [this gist](https://gist.github.com/2588577).

I set the sbt version to 0.12.0-Beta2, as the required `Graph.toAscii` is only available in sbt >= 0.12.x
I disabled all build plugins locally, not sure if there are already versions available for 0.12.

I hope you find the time to merge these changes.

Best regards,
  Gerolf
