### PR TITLE
Correctly match a version like 0.12.1-foo as 0.12.1

### DIFF
--- a/src/main/scala/net/virtualvoid/sbt/graph/Plugin.scala
+++ b/src/main/scala/net/virtualvoid/sbt/graph/Plugin.scala
@@ -59,7 +59,7 @@ object Plugin extends sbt.Plugin {
   def graphSettings = seq(
     ivyReportFunction <<= (sbtVersion, target, projectID, ivyModule, appConfiguration, streams) map { (sbtV, target, projectID, ivyModule, config, streams) =>
       sbtV match {
-        case Version(0, min, fix) if min > 12 || (min == 12 && fix >= 1) =>
+        case Version(0, min, fix, _) if min > 12 || (min == 12 && fix >= 1) =>
           ivyModule.withModule(streams.log) { (i, moduleDesc, _) =>
             val id = ResolveOptions.getDefaultResolveId(moduleDesc)
             (c: String) => file("%s/resolution-cache/reports/%s/%s-resolved.xml" format (target, id,c))


### PR DESCRIPTION
An organization that has had to fork sbt is likely to change the version
slightly.  The code is intended to match 0.12.1-foo as a 0.12.1 version,
but in fact without this change does not.
