### PR TITLE
Use v0.4.16 of dagre-d3 to avoid javascript error

### DIFF
--- a/src/main/resources/graph.html
+++ b/src/main/resources/graph.html
@@ -33,7 +33,7 @@ THE SOFTWARE.
 <script src="http://d3js.org/d3.v3.js"></script>
 <script src="http://cpettitt.github.io/project/graphlib-dot/v0.6.1/graphlib-dot.js"></script>
 <script src="http://code.jquery.com/jquery-2.1.4.min.js"></script>
-<script src="http://cpettitt.github.io/project/dagre-d3/v0.4.10/dagre-d3.min.js"></script>
+<script src="http://cpettitt.github.io/project/dagre-d3/v0.4.16/dagre-d3.min.js"></script>
 <script src="dependencies.dot.js"></script>
 
 <style>


### PR DESCRIPTION
When using `dagre-d3` v0.4.10, my browser (Chrome 49) crashes an javascript error and the arrows are not displayed :
```
Uncaught TypeError: t.getTransformToElement is not a function
```
This happens in the function `getCoords` of the library.

Using the latest version of `dagre-d3` (v0.4.16) fixes the issue.