### PR TITLE
Fix link to Compatibility notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Visualize your project's dependencies.
 
 ## Preliminaries
 
-The plugin works best with sbt >= 0.13.6. See the [compatibility notes](#Compatibility-notes) to use this plugin with an older version of sbt.
+The plugin works best with sbt >= 0.13.6. See the [compatibility notes](#compatibility-notes) to use this plugin with an older version of sbt.
 
 ## Usage Instructions
 


### PR DESCRIPTION
For me at least on GitHub the current link doesn't work..