### PR TITLE
new task dependencyHomepageInfo and filtering by regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This plugin is an auto-plugin which will be automatically enabled starting from 
  * `whatDependsOn <organization> <module> <revision>`: Find out what depends on an artifact. Shows a reverse dependency
    tree for the selected module.
  * `dependencyLicenseInfo`: show dependencies grouped by declared license
+ * `dependencyHomepageInfo`: show dependencies' homepage info
  * `dependencyStats`: Shows a table with each module a row with (transitive) Jar sizes and number of dependencies
  * `dependencyGraphMl`: Generates a `.graphml` file with the project's dependencies to `target/dependencies-<config>.graphml`.
    Use e.g. [yEd](http://www.yworks.com/en/products_yed_about.html) to format the graph to your needs.
@@ -46,6 +47,7 @@ assumed as usual.
  * `filterScalaLibrary`: Defines if the scala library should be excluded from the output of the dependency-* functions.
    If `true`, instead of showing the dependency `"[S]"` is appended to the artifact name. Set to `false` if
    you want the scala-library dependency to appear in the output. (default: true)
+ * `dependencyFilter`: defines regexp expression to list dependencies for task `dependencyHomepageInfo`  
  * `dependencyGraphMLFile`: a setting which allows configuring the output path of `dependency-graph-ml`.
  * `dependencyDotFile`: a setting which allows configuring the output path of `dependency-dot`.
  * `dependencyDotHeader`: a setting to customize the header of the dot file (e.g. to set your preferred node shapes).

--- a/src/main/scala/net/virtualvoid/sbt/graph/DependencyGraphKeys.scala
+++ b/src/main/scala/net/virtualvoid/sbt/graph/DependencyGraphKeys.scala
@@ -64,9 +64,14 @@ trait DependencyGraphKeys {
   val ignoreMissingUpdate = Keys.update in ivyReport
   val filterScalaLibrary = SettingKey[Boolean]("filter-scala-library",
     "Specifies if scala dependency should be filtered in dependency-* output")
+  val dependencyFilter = SettingKey[String]("filter-dependencies",
+    "Specifies regex expression to filter dependencies listed")
 
   val licenseInfo = TaskKey[Unit]("dependency-license-info",
     "Aggregates and shows information about the licenses of dependencies")
+
+  val homepageInfo = TaskKey[Unit]("dependency-homepage-info",
+    "Homepage information about dependencies")
 
   // internal
   private[graph] val moduleGraphStore = TaskKey[ModuleGraph]("module-graph-store", "The stored module-graph from the last run")

--- a/src/main/scala/net/virtualvoid/sbt/graph/backend/SbtUpdateReport.scala
+++ b/src/main/scala/net/virtualvoid/sbt/graph/backend/SbtUpdateReport.scala
@@ -38,6 +38,7 @@ object SbtUpdateReport {
       (Module(
         id = report.module,
         license = report.licenses.headOption.map(_._1),
+        homepage = report.homepage,
         evictedByVersion = evictedByVersion,
         jarFile = jarFile,
         error = report.problem),

--- a/src/main/scala/net/virtualvoid/sbt/graph/model.scala
+++ b/src/main/scala/net/virtualvoid/sbt/graph/model.scala
@@ -27,6 +27,7 @@ case class ModuleId(organisation: String,
 }
 case class Module(id: ModuleId,
                   license: Option[String] = None,
+                  homepage: Option[String] = None,
                   extraInfo: String = "",
                   evictedByVersion: Option[String] = None,
                   jarFile: Option[File] = None,
@@ -65,6 +66,6 @@ import sbinary.{ Format, DefaultProtocol }
 object ModuleGraphProtocol extends DefaultProtocol {
   implicit def seqFormat[T: Format]: Format[Seq[T]] = wrap[Seq[T], List[T]](_.toList, _.toSeq)
   implicit val ModuleIdFormat: Format[ModuleId] = asProduct3(ModuleId)(ModuleId.unapply(_).get)
-  implicit val ModuleFormat: Format[Module] = asProduct6(Module)(Module.unapply(_).get)
+  implicit val ModuleFormat: Format[Module] = asProduct7(Module)(Module.unapply(_).get)
   implicit val ModuleGraphFormat: Format[ModuleGraph] = asProduct2(ModuleGraph.apply _)(ModuleGraph.unapply(_).get)
 }


### PR DESCRIPTION
I have extended the plugin to list dependencies homepage info. We are using this to report changes in the project with respective changes listed on module's homepage. There is also a filter used to list only some dependencies. This could be maybe use for all tasks, but in this pull request it is for the new task only