### PR TITLE
Generate reports for projects using IntegrationTest config

### DIFF
--- a/src/main/scala/net/virtualvoid/sbt/graph/DependencyGraphSettings.scala
+++ b/src/main/scala/net/virtualvoid/sbt/graph/DependencyGraphSettings.scala
@@ -37,7 +37,7 @@ object DependencyGraphSettings {
     ivyReportFunction <<= ivyReportFunctionTask,
     updateConfiguration in ignoreMissingUpdate <<= updateConfiguration(config ⇒ new UpdateConfiguration(config.retrieve, true, config.logging)),
     ignoreMissingUpdateT,
-    filterScalaLibrary in Global := true) ++ Seq(Compile, Test, Runtime, Provided, Optional).flatMap(ivyReportForConfig)
+    filterScalaLibrary in Global := true) ++ Seq(Compile, Test, IntegrationTest, Runtime, Provided, Optional).flatMap(ivyReportForConfig)
 
   def ivyReportForConfig(config: Configuration) = inConfig(config)(Seq(
     ivyReport <<= ivyReportFunction map (_(config.toString)) dependsOn (ignoreMissingUpdate),

--- a/src/main/scala/net/virtualvoid/sbt/graph/DependencyGraphSettings.scala
+++ b/src/main/scala/net/virtualvoid/sbt/graph/DependencyGraphSettings.scala
@@ -122,7 +122,7 @@ object DependencyGraphSettings {
   def moduleGraphIvyReportTask = ivyReport map (absoluteReportPath.andThen(IvyReport.fromReportFile))
   def moduleGraphSbtTask =
     (ignoreMissingUpdate, crossProjectId, configuration) map { (update, root, config) ⇒
-      SbtUpdateReport.fromConfigurationReport(update.configuration(config.name).get, root)
+      update.configuration(config.name).map(report ⇒ SbtUpdateReport.fromConfigurationReport(report, root)).getOrElse(ModuleGraph.empty)
     }
 
   def printAsciiGraphTask =

--- a/src/main/scala/net/virtualvoid/sbt/graph/model.scala
+++ b/src/main/scala/net/virtualvoid/sbt/graph/model.scala
@@ -36,6 +36,10 @@ case class Module(id: ModuleId,
   def isEvicted: Boolean = evictedByVersion.isDefined
 }
 
+object ModuleGraph {
+  val empty = ModuleGraph(Seq.empty, Seq.empty)
+}
+
 case class ModuleGraph(nodes: Seq[Module], edges: Seq[Edge]) {
   lazy val modules: Map[ModuleId, Module] =
     nodes.map(n ⇒ (n.id, n)).toMap


### PR DESCRIPTION
I noticed that the `IntegrationTest` config was missing from the default settings. Since sbt provides this config, I imagine it'd be safe to include it as a default here. 

I also updated `moduleGraphSbtTask` to return an empty graph if the configuration isn't used to ensure that exceptions aren't thrown if a specific configuration isn't in use for a specific project.