### PR TITLE
Partial scala 2.12 build support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,16 @@
+scalaVersion := (CrossVersion partialVersion (sbtVersion in pluginCrossBuild).value match {
+  case Some((0, 13)) => "2.10.6"
+  case Some((1, _))  => "2.12.2"
+  case _             => sys error s"Unhandled sbt version ${(sbtVersion in pluginCrossBuild).value}"
+})
+
 ScriptedPlugin.scriptedSettings
 
-libraryDependencies += "com.github.mdr" %% "ascii-graphs" % "0.0.3"
+libraryDependencies += "com.github.mdr" % "ascii-graphs_2.10" % "0.0.3"
 
-libraryDependencies += "org.specs2" %% "specs2" % "2.3.11" % "test"
+libraryDependencies += "org.specs2" %% "specs2-core" % "3.9.4" % "test"
+
+crossSbtVersions := Vector("0.13.16", "1.0.0")
 
 scalacOptions ++= Seq("-deprecation", "-unchecked")
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.16

--- a/project/pgp.sbt
+++ b/project/pgp.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0-M1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.2.1")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.0")


### PR DESCRIPTION
Please feel free to ignore. Relates to https://github.com/jrudolph/sbt-dependency-graph/issues/134
I couldn't get the scala 2.12 build to work due to macros not building.
ascii-graphs does not have a scala 2.12 compatible jar but the scala 2.10 jar doesn't seem to cause immediate issues in a scala 2.12 build.

