### PR TITLE
add file-output option to dependencyTree

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ the notes of version [0.8.2](https://github.com/jrudolph/sbt-dependency-graph/tr
 ## Main Tasks
 
  * `dependencyTree`: Shows an ASCII tree representation of the project's dependencies
+   * write output to a file by passing `-o <output path>` arguments
  * `dependencyBrowseGraph`: Opens a browser window with a visualization of the dependency graph (courtesy of graphlib-dot + dagre-d3).
  * `dependencyList`: Shows a flat list of all transitive dependencies on the sbt console (sorted by organization and name)
  * `whatDependsOn <organization> <module> <revision>`: Find out what depends on an artifact. Shows a reverse dependency

--- a/src/main/scala/net/virtualvoid/sbt/graph/DependencyGraphKeys.scala
+++ b/src/main/scala/net/virtualvoid/sbt/graph/DependencyGraphKeys.scala
@@ -51,7 +51,7 @@ trait DependencyGraphKeys {
     "Prints the ascii graph to the console")
   val asciiTree = TaskKey[String]("dependency-tree-string",
     "Returns a string containing an ascii tree representation of the dependency graph for a project")
-  val dependencyTree = TaskKey[Unit]("dependency-tree",
+  val dependencyTree = InputKey[Unit]("dependency-tree",
     "Prints an ascii tree of all the dependencies to the console")
   val dependencyList = TaskKey[Unit]("dependency-list",
     "Prints a list of all dependencies to the console")

--- a/src/sbt-test/sbt-dependency-graph/dependencyTreeFile/build.sbt
+++ b/src/sbt-test/sbt-dependency-graph/dependencyTreeFile/build.sbt
@@ -1,0 +1,30 @@
+import java.nio.file.{ Files, Paths }
+
+import scala.io.Source
+
+scalaVersion := "2.9.1"
+
+resolvers += "typesafe maven" at "https://repo.typesafe.com/typesafe/maven-releases/"
+
+libraryDependencies ++= Seq(
+  "com.codahale" % "jerkson_2.9.1" % "0.5.0"
+)
+
+InputKey[Unit]("check") := {
+  val is = Files.newInputStream(Paths.get("foo"))
+  val tree = Source.fromInputStream(is).mkString
+  is.close()
+
+  require(
+    tree ==
+    """default:dependencytreefile_2.9.1:0.1-SNAPSHOT [S]
+      |  +-com.codahale:jerkson_2.9.1:0.5.0 [S]
+      |    +-org.codehaus.jackson:jackson-core-asl:1.9.11
+      |    +-org.codehaus.jackson:jackson-mapper-asl:1.9.11
+      |      +-org.codehaus.jackson:jackson-core-asl:1.9.11
+      |      """
+      .stripMargin,
+    s"Tree didn't match expected:\n$tree"
+  )
+  ()
+}

--- a/src/sbt-test/sbt-dependency-graph/dependencyTreeFile/project/plugins.sbt
+++ b/src/sbt-test/sbt-dependency-graph/dependencyTreeFile/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % sys.props("project.version"))

--- a/src/sbt-test/sbt-dependency-graph/dependencyTreeFile/test
+++ b/src/sbt-test/sbt-dependency-graph/dependencyTreeFile/test
@@ -1,0 +1,2 @@
+> dependencyTree -o foo
+> check


### PR DESCRIPTION
fixes #71 

I released `org.hammerlab:sbt-dependency-graph:0.10.1` with this feature and #145 