### PR TITLE
Avoid http redirect in dependencyBrowseGraph

### DIFF
--- a/src/main/resources/graph.html
+++ b/src/main/resources/graph.html
@@ -32,8 +32,8 @@ THE SOFTWARE.
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
-<script src="https://cpettitt.github.io/project/graphlib-dot/v0.6.1/graphlib-dot.js"></script>
-<script src="https://cpettitt.github.io/project/dagre-d3/v0.4.16/dagre-d3.min.js"></script>
+<script src="https://www.samsarin.com/project/graphlib-dot/v0.6.1/graphlib-dot.js"></script>
+<script src="https://www.samsarin.com/project/dagre-d3/v0.4.16/dagre-d3.min.js"></script>
 <script src="dependencies.dot.js"></script>
 
 <style>


### PR DESCRIPTION
I published a dependency graph at https://github.com/MasseGuillaume/spark-dependency-graph

and I noticed that https://cpettitt.github.io/project/graphlib-dot/v0.6.1/graphlib-dot.js redirects to
http://www.samsarin.com/project/graphlib-dot/v0.6.1/graphlib-dot.js

this causes the script to fail over insecure content.