### PR TITLE
Don't fail in parsing when whatDependsOn is called without running any other command first, fixes #95

### DIFF
--- a/src/main/scala/net/virtualvoid/sbt/graph/DependencyGraphSettings.scala
+++ b/src/main/scala/net/virtualvoid/sbt/graph/DependencyGraphSettings.scala
@@ -197,7 +197,13 @@ object DependencyGraphSettings {
               case ((org, name), version) ⇒ ArtifactPattern(org, name, version)
             }
         }
-        .reduceOption(_ | _).getOrElse(failure("No dependencies found"))
+        .reduceOption(_ | _).getOrElse {
+          // If the moduleGraphStore couldn't be loaded because no dependency tree command was run before, we should still provide a parser for the command.
+          ((Space ~> token(StringBasic, "<organization>")) ~ (Space ~> token(StringBasic, "<module>")) ~ (Space ~> token(StringBasic, "<version?>")).?).map {
+            case ((org, mod), version) ⇒
+              ArtifactPattern(org, mod, version)
+          }
+        }
     }
 
   // This is to support 0.13.8's InlineConfigurationWithExcludes while not forcing 0.13.8

--- a/src/sbt-test/sbt-dependency-graph/whatDependsOn-without-previous-initialization/build.sbt
+++ b/src/sbt-test/sbt-dependency-graph/whatDependsOn-without-previous-initialization/build.sbt
@@ -1,0 +1,56 @@
+version := "0.1.0-SNAPSHOT"
+
+organization := "default"
+
+name := "whatDependsOn"
+
+scalaVersion := "2.9.1"
+
+resolvers += "typesafe maven" at "https://repo.typesafe.com/typesafe/maven-releases/"
+
+libraryDependencies ++= Seq(
+  "com.codahale" % "jerkson_2.9.1" % "0.5.0",
+  "org.codehaus.jackson" % "jackson-mapper-asl" % "1.9.10" // as another version of asl
+)
+
+val check = TaskKey[Unit]("check")
+
+check := {
+  def sanitize(str: String): String = str.split('\n').map(_.trim).mkString("\n")
+  def checkOutput(output: String, expected: String): Unit =
+    require(sanitize(expected) == sanitize(output), s"Tree should have been [\n${sanitize(expected)}\n] but was [\n${sanitize(output)}\n]")
+
+  val withVersion =
+    (whatDependsOn in Compile)
+      .toTask(" org.codehaus.jackson jackson-core-asl 1.9.11")
+      .value
+  val expectedGraphWithVersion =
+    """org.codehaus.jackson:jackson-core-asl:1.9.11
+      |  +-com.codahale:jerkson_2.9.1:0.5.0 [S]
+      |  | +-default:whatdependson_2.9.1:0.1.0-SNAPSHOT [S]
+      |  |
+      |  +-org.codehaus.jackson:jackson-mapper-asl:1.9.11
+      |    +-com.codahale:jerkson_2.9.1:0.5.0 [S]
+      |    | +-default:whatdependson_2.9.1:0.1.0-SNAPSHOT [S]
+      |    |
+      |    +-default:whatdependson_2.9.1:0.1.0-SNAPSHOT [S]
+      |  """.stripMargin
+
+  checkOutput(withVersion, expectedGraphWithVersion)
+
+  val withoutVersion =
+    (whatDependsOn in Compile)
+      .toTask(" org.codehaus.jackson jackson-mapper-asl")
+      .value
+  val expectedGraphWithoutVersion =
+    """org.codehaus.jackson:jackson-mapper-asl:1.9.11
+      | +-com.codahale:jerkson_2.9.1:0.5.0 [S]
+      | | +-default:whatdependson_2.9.1:0.1.0-SNAPSHOT [S]
+      | |
+      | +-default:whatdependson_2.9.1:0.1.0-SNAPSHOT [S]
+      |
+      |org.codehaus.jackson:jackson-mapper-asl:1.9.10 (evicted by: 1.9.11)
+      | +-default:whatdependson_2.9.1:0.1.0-SNAPSHOT [S]
+      |   """.stripMargin
+  checkOutput(withoutVersion, expectedGraphWithoutVersion)
+}

--- a/src/sbt-test/sbt-dependency-graph/whatDependsOn-without-previous-initialization/project/plugins.sbt
+++ b/src/sbt-test/sbt-dependency-graph/whatDependsOn-without-previous-initialization/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % sys.props("project.version"))

--- a/src/sbt-test/sbt-dependency-graph/whatDependsOn-without-previous-initialization/test
+++ b/src/sbt-test/sbt-dependency-graph/whatDependsOn-without-previous-initialization/test
@@ -1,0 +1,2 @@
+# same as whatDependsOn test but without the initialization to prime the parser
+> check


### PR DESCRIPTION
If no other command was run first, tab completion runs now in degraded mode
again, not showing any concrete suggestions but just the general syntax.

This probably regressed in #155 where I probably couldn't remember the reason
for the fallback.