### PR TITLE
Added support for overriding column length: Resolves issue 173

### DIFF
--- a/src/main/scala-sbt-0.13/net/virtualvoid/sbt/graph/rendering/AsciiGraph.scala
+++ b/src/main/scala-sbt-0.13/net/virtualvoid/sbt/graph/rendering/AsciiGraph.scala
@@ -19,6 +19,7 @@ package rendering
 
 import com.github.mdr.ascii.layout._
 import net.virtualvoid.sbt.graph.DependencyGraphKeys._
+import sbt.dependencygraph.DependencyGraphSbtCompat.Settings.asciiGraphMaxColumnWidth
 import sbt.Keys._
 
 object AsciiGraph {
@@ -42,6 +43,7 @@ object AsciiGraph {
     DependencyGraphKeys.asciiGraph := asciiGraph(moduleGraph.value),
     dependencyGraph := {
       val force = DependencyGraphSettings.shouldForceParser.parsed
+      val columnWidth = asciiGraphMaxColumnWidth.value
       val log = streams.value.log
       if (force || moduleGraph.value.nodes.size < 15) {
         log.info(rendering.AsciiGraph.asciiGraph(moduleGraph.value))
@@ -49,7 +51,7 @@ object AsciiGraph {
         log.info("Note: The old tree layout is still available by using `dependency-tree`")
       }
 
-      log.info(rendering.AsciiTree.asciiTree(moduleGraph.value))
+      log.info(rendering.AsciiTree.asciiTree(moduleGraph.value, columnWidth))
 
       if (!force) {
         log.info("\n")

--- a/src/main/scala-sbt-0.13/sbt/dependencygraph/DependencyGraphSbtCompat.scala
+++ b/src/main/scala-sbt-0.13/sbt/dependencygraph/DependencyGraphSbtCompat.scala
@@ -1,6 +1,7 @@
 package sbt
 package dependencygraph
 
+import scala.util.Try
 import scala.language.implicitConversions
 
 object DependencyGraphSbtCompat {
@@ -11,5 +12,19 @@ object DependencyGraphSbtCompat {
       def withMissingOk(missingOk: Boolean): UpdateConfiguration =
         updateConfig.copy(missingOk = missingOk)
     }
+  }
+
+  object Settings {
+    private val sbtAsciiGraphWidth = "SBT_ASCII_GRAPH_WIDTH"
+
+    val asciiGraphMaxColumnWidth = Def.setting(defaultColumnSize)
+
+    private def defaultColumnSize: Int = {
+      val envAsciiWidth = sys.env.get(sbtAsciiGraphWidth).flatMap(s ⇒ Try(s.toInt).toOption)
+      val termWidth = envAsciiWidth.getOrElse(SbtAccess.getTerminalWidth)
+      if (termWidth > 20) termWidth - 8
+      else 80 // ignore termWidth
+    }
+
   }
 }

--- a/src/main/scala-sbt-1.0/sbt/dependencygraph/DependencyGraphSbtCompat.scala
+++ b/src/main/scala-sbt-1.0/sbt/dependencygraph/DependencyGraphSbtCompat.scala
@@ -3,4 +3,8 @@ package dependencygraph
 
 object DependencyGraphSbtCompat {
   object Implicits
+
+  object Settings {
+    val asciiGraphMaxColumnWidth = Def.setting(sbt.Keys.asciiGraphWidth.value)
+  }
 }

--- a/src/main/scala/net/virtualvoid/sbt/graph/DependencyGraphSettings.scala
+++ b/src/main/scala/net/virtualvoid/sbt/graph/DependencyGraphSettings.scala
@@ -27,6 +27,7 @@ import internal.librarymanagement._
 import librarymanagement._
 import sbt.dependencygraph.SbtAccess
 import sbt.dependencygraph.DependencyGraphSbtCompat.Implicits._
+import sbt.dependencygraph.DependencyGraphSbtCompat.Settings.asciiGraphMaxColumnWidth
 import sbt.complete.Parsers
 
 object DependencyGraphSettings {
@@ -48,12 +49,12 @@ object DependencyGraphSettings {
   def reportSettings =
     Seq(Compile, Test, IntegrationTest, Runtime, Provided, Optional).flatMap(ivyReportForConfig)
 
-  val renderingAlternatives: Seq[(TaskKey[Unit], ModuleGraph ⇒ String)] =
+  val renderingAlternatives: Seq[(TaskKey[Unit], Def.Initialize[Task[ModuleGraph ⇒ String]])] =
     Seq(
-      dependencyTree -> rendering.AsciiTree.asciiTree _,
-      dependencyList -> rendering.FlatList.render(_.id.idString),
-      dependencyStats -> rendering.Statistics.renderModuleStatsList _,
-      licenseInfo -> rendering.LicenseInfo.render _)
+      dependencyTree -> Def.task(rendering.AsciiTree.asciiTree(_, asciiGraphMaxColumnWidth.value)),
+      dependencyList -> Def.task(rendering.FlatList.render(_.id.idString)),
+      dependencyStats -> Def.task(rendering.Statistics.renderModuleStatsList _),
+      licenseInfo -> Def.task(rendering.LicenseInfo.render _))
 
   def ivyReportForConfig(config: Configuration) = inConfig(config)(
     Seq(
@@ -107,6 +108,7 @@ object DependencyGraphSettings {
 
       whatDependsOn := {
         val ArtifactPattern(org, name, versionFilter) = artifactPatternParser.parsed
+        val maxColumnSize = asciiGraphMaxColumnWidth.value
         val graph = moduleGraph.value
         val modules =
           versionFilter match {
@@ -116,7 +118,7 @@ object DependencyGraphSettings {
         val output =
           modules
             .map { module ⇒
-              rendering.AsciiTree.asciiTree(GraphTransformations.reverseGraphStartingAt(graph, module))
+              rendering.AsciiTree.asciiTree(GraphTransformations.reverseGraphStartingAt(graph, module), maxColumnSize)
             }
             .mkString("\n")
 
@@ -128,9 +130,9 @@ object DependencyGraphSettings {
       renderingAlternatives.flatMap((renderingTaskSettings _).tupled) ++
       AsciiGraph.asciiGraphSetttings)
 
-  def renderingTaskSettings(key: TaskKey[Unit], renderer: ModuleGraph ⇒ String): Seq[Setting[_]] =
+  def renderingTaskSettings(key: TaskKey[Unit], renderer: Def.Initialize[Task[ModuleGraph ⇒ String]]): Seq[Setting[_]] =
     Seq(
-      asString in key := renderer(moduleGraph.value),
+      asString in key := renderer.value(moduleGraph.value),
       printToConsole in key := streams.value.log.info((asString in key).value),
       toFile in key := {
         val (targetFile, force) = targetFileAndForceParser.parsed

--- a/src/main/scala/net/virtualvoid/sbt/graph/rendering/AsciiTree.scala
+++ b/src/main/scala/net/virtualvoid/sbt/graph/rendering/AsciiTree.scala
@@ -21,13 +21,13 @@ import util.AsciiTreeLayout
 import util.ConsoleUtils._
 
 object AsciiTree {
-  def asciiTree(graph: ModuleGraph): String = {
+  def asciiTree(graph: ModuleGraph, maxColumnWidth: Int): String = {
     val deps = graph.dependencyMap
 
     // there should only be one root node (the project itself)
     val roots = graph.roots
     roots.map { root ⇒
-      AsciiTreeLayout.toAscii[Module](root, node ⇒ deps.getOrElse(node.id, Seq.empty[Module]), displayModule)
+      AsciiTreeLayout.toAscii[Module](root, node ⇒ deps.getOrElse(node.id, Seq.empty[Module]), displayModule, maxColumnWidth)
     }.mkString("\n")
   }
 


### PR DESCRIPTION
This is an MR adding support for overriding the terminal column width when rendering ASCII graphs (e.g. dependencyTree)

This uses the inbuilt sbt 1.0 functionality with `asciiGraphWidth`