### PR TITLE
Change the dependency graph's width to the width of the browser window

### DIFF
--- a/src/main/resources/graph.html
+++ b/src/main/resources/graph.html
@@ -78,7 +78,7 @@ THE SOFTWARE.
 
 <h1>Dependencies</h1>
 
-<svg width=1280 height=1024>
+<svg width=100% height=1024>
     <g/>
 </svg>
 


### PR DESCRIPTION
In my projects I often have a very dense graph, which just doesn't fit into a 1280x1024 canvas, and also this makes the graph a bit more responsive.