### PR TITLE
Added support for environments without tty

### DIFF
--- a/src/main/scala/sbt/dependencygraph/SbtAccess.scala
+++ b/src/main/scala/sbt/dependencygraph/SbtAccess.scala
@@ -23,7 +23,9 @@ import Def._
 object SbtAccess {
   val unmanagedScalaInstanceOnly = Defaults.unmanagedScalaInstanceOnly
 
-  def getTerminalWidth: Int = sbt.internal.util.JLine.usingTerminal(_.getWidth)
+  def getTerminalWidth: Int = sbt.internal.util.JLine.usingTerminal { term ⇒
+    if (!term.isSupported) Int.MaxValue else term.getWidth
+  }
 
   def inTask[T](t: Scoped, i: Initialize[T]): Initialize[T] = _root_.sbt.inTask(t, i)
 }


### PR DESCRIPTION
This is an PR adding support to avoid truncating trees in environments without tty and resolves issue 173 simply.

jline2 creates an UnsupportedTerminal in environments that do not have a tty, but it has a column size of 80.