### PR TITLE
Optimize the screen space for dependencyBrowseGraph

### DIFF
--- a/src/main/resources/graph.html
+++ b/src/main/resources/graph.html
@@ -37,11 +37,10 @@ THE SOFTWARE.
 <script src="dependencies.dot.js"></script>
 
 <style>
-    svg {
-        border: 1px solid #999;
+    body {
+        margin: 0;
         overflow: hidden;
     }
-
     .node {
         white-space: nowrap;
     }
@@ -76,8 +75,6 @@ THE SOFTWARE.
 
 <body onLoad="initialize()">
 
-<h1>Dependencies</h1>
-
 <svg width=1280 height=1024>
     <g/>
 </svg>
@@ -91,6 +88,8 @@ function initialize() {
           inner.attr("transform", "translate(" + d3.event.translate + ")" +
                                       "scale(" + d3.event.scale + ")");
         });
+    svg.attr("width", window.innerWidth);
+
     svg.call(zoom);
     // Create and configure the renderer
     var render = dagreD3.render();
@@ -98,21 +97,11 @@ function initialize() {
       var g;
       {
         g = graphlibDot.read(inputGraph);
-        // Set margins, if not present
-        if (!g.graph().hasOwnProperty("marginx") &&
-            !g.graph().hasOwnProperty("marginy")) {
-          g.graph().marginx = 20;
-          g.graph().marginy = 20;
-          g.graph().rankdir = "LR";
-        }
-        g.graph().transition = function(selection) {
-          return selection.transition().duration(500);
-        };
-        // Render the graph into svg g
+        g.graph().rankdir = "LR";
         d3.select("svg g").call(render, g);
 
         // Center the graph
-        var initialScale = 0.75;
+        var initialScale = 0.10;
         zoom
           .translate([(svg.attr("width") - g.graph().width * initialScale) / 2, 20])
           .scale(initialScale)


### PR DESCRIPTION
* The width was limited to 1280, I just take whatever the browser can give be.
* Remove the default 8px margin from the browser default
* Remove the title, it takes vertical space
* The scale was a bit small for large graph, start really far away
* Remove the graph margin, but keep the organization left to right (default is top-down).

![Screenshot from 2020-07-13 15-28-08](https://user-images.githubusercontent.com/921490/87345173-ad462400-c51d-11ea-85a2-51af97cfac69.png)

![Screenshot from 2020-07-13 15-28-25](https://user-images.githubusercontent.com/921490/87345181-b1724180-c51d-11ea-8147-3403518aadb0.png)
